### PR TITLE
feat: add build tag to skip special iprange handling for tinygo

### DIFF
--- a/ip_isprivate.go
+++ b/ip_isprivate.go
@@ -1,0 +1,9 @@
+//go:build !tinygo
+
+package plugin
+
+import "net"
+
+func IsSpecialIpRangeToBeSkipped(ip net.IP) bool {
+	return ip.IsPrivate() || ip.IsLoopback() || ip.IsUnspecified()
+}

--- a/ip_isprivate_tinygo.go
+++ b/ip_isprivate_tinygo.go
@@ -1,0 +1,11 @@
+//go:build tinygo
+
+package plugin
+
+import "net"
+
+func IsSpecialIpRangeToBeSkipped(ip net.IP) bool {
+	//"IsPrivate" is not defined for tinygo, see: tinygo.org/docs/reference/lang-support/stdlib/#netnetip
+	// therfore we return false here
+	return false
+}

--- a/operators_logic.go
+++ b/operators_logic.go
@@ -71,7 +71,7 @@ func (o *geo) executeEvaluationInternal(tx transaction, value string) (bool, err
 		return false, fmt.Errorf("invalid ip %q", value)
 	}
 
-	if ip.IsPrivate() || ip.IsLoopback() || ip.IsUnspecified() {
+	if IsSpecialIpRangeToBeSkipped(ip) {
 		return false, nil
 	}
 


### PR DESCRIPTION
This PR adds a new buildtag "tinygo". If this is set, special IP handling is not executed as it is not implemented in tinygo.

see: tinygo.org/docs/reference/lang-support/stdlib/#netnetip